### PR TITLE
optimize GLSL shaders for grayscale images

### DIFF
--- a/js/shaders.js
+++ b/js/shaders.js
@@ -23,8 +23,8 @@ uniform sampler2D uClutSampler;\
 void main(void) {  \
     highp vec4 texcolor = texture2D(uSampler, vTextureCoord); \
     highp float intensity = texcolor.r*65536.0;\
-    highp float lower_bound = uWL - uWW/2.0;\
-    highp float upper_bound = uWL + uWW/2.0;\
+    highp float lower_bound = (uWW * -0.5) + uWL; \
+    highp float upper_bound = (uWW *  0.5) + uWL; \
     intensity = (intensity - lower_bound)/(upper_bound - lower_bound);\
 \
     gl_FragColor = vec4(intensity, intensity, intensity, uAlpha);\
@@ -47,8 +47,8 @@ void main(void) {  \
     highp float rescaleIntercept = uRI;\
     highp float rescaleSlope = uRS;\
     intensity = intensity * rescaleSlope + rescaleIntercept;\
-    highp float lower_bound = uWL - uWW/2.0;\
-    highp float upper_bound = uWL + uWW/2.0;\
+    highp float lower_bound = (uWW * -0.5) + uWL; \
+    highp float upper_bound = (uWW *  0.5) + uWL; \
     intensity = (intensity - lower_bound)/(upper_bound - lower_bound);\
     highp vec4 clutcolor = texture2D(uClutSampler, vec2(intensity, intensity)); \
     gl_FragColor = vec4(clutcolor.r, clutcolor.g, clutcolor.b, uAlpha);\


### PR DESCRIPTION
this small commit changes the upper/lower VOI window bound calculations
to be more optimization friendly so most GLSL compilers can turn them into
a single-cycle multiply-and-add operation.
